### PR TITLE
Galaxy XR Updated Info

### DIFF
--- a/brands/samsung/README.md
+++ b/brands/samsung/README.md
@@ -35,7 +35,9 @@ Until recently, international Samsung devices (e.g. ones sold in Europe or Asia)
 > 
 > </details>
 
-Despite the removal of bootloader unlocks in One UI 8, the Galaxy XR, Samsung's AR headset, [does have][xr bootloader unlock] an unlockable bootloader.
+The Galaxy XR, Samsung's XR headset, does NOT have an unlockable bootloader as of the December 9th, 2025 update, this was the headset's first update post-launch. Firmware prior to this date have an unlockable bootloader.  
+The April 8th, 2026 update now seemingly prevents downgrading to older firmware that allows for unlocking the booloader.  
+[Source](https://doc.samsungmobile.com/SM-I610/TXV/doc.html). Note the change: ``The device is protected with improved security.``
 
 Snapdragon phones prior to the S7/Note7 (2016) can be unlocked regardless of region, as long as it's not locked to a carrier like AT&T or Verizon. The Canadian S7 can also be unlocked as it uses an Exynos SoC, despite Canada normally being a Snapdragon region.
 


### PR DESCRIPTION
The information about the Galaxy XR having an unlockable bootloader was true at launch, but an update pushed two months after launch removed the feature.