### PR TITLE
cleanup Xiaomi's page

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If bootloader unlocking doesn't work on an Oppo Mediatek device using the SECCFG
 
 On Snapdragon 8E5, Qualcomm introduced a [vulnerability (CN)](https://www.cnblogs.com/sakrain/p/-/unlock-your-qualcomm) [(POC)](https://github.com/kasnria001/qualcomm_gbl_exploit_poc) where the boot process would not perform signature verification for the Generic Bootloader, so with write access to the `efisp` partition it was possible to run arbitary code.
 
-While the vulnerability itself is universal for the platform, it requires device/OEM specific tricks to get root and write the GBL. A lot of those exist for [Xiaomi devices](./brands/xiaomi/README.md#workarounds-use-at-your-own-risk).
+While the vulnerability itself is universal for the platform, it requires device/OEM specific tricks to get root and write the GBL. Some exist for [Xiaomi devices](./brands/xiaomi/README.md#snapdragon-8-elite).
 
 #### Other
 

--- a/README.md
+++ b/README.md
@@ -169,17 +169,19 @@ If it also happens to be an OPPO/Realme device and you need to access fastboot: 
 If bootloader unlocking doesn't work on an Oppo Mediatek device using the SECCFG mod (unlocking via mtkclient), you can try unlocking fastboot by writing a modified boot1 (preloader). Writing a preloader also uses mtckclient: [oppo-mtk-fastboot-unlock](https://github.com/Shocked-Cat/oppo-mtk-fastboot-unlock).
 
 ### Qualcomm 
-On the Chinese app Coolapk, a method to unlock all Snapdragon 8E5 devices has been leaked. For Xiaomi devices, all 8E5/8E models can be unlocked if they have a security patch dated before February 2026; devices updated after February 2026 have already been patched.
 
-[XDA](https://xdaforums.com/t/qualcomm-there-seems-to-be-a-0-day-vulnerability-that-can-be-used-to-unlock-the-bootloader.4776970/)
+#### Snapdragon 8 Elite Gen 5
 
-Although some of these might work for you:
+**Patched in February/March 2026**
+
+On Snapdragon 8E5, Qualcomm introduced a [vulnerability (CN)](https://www.cnblogs.com/sakrain/p/-/unlock-your-qualcomm) [(POC)](https://github.com/kasnria001/qualcomm_gbl_exploit_poc) where the boot process would not perform signature verification for the Generic Bootloader, so with write access to the `efisp` partition it was possible to run arbitary code.
+
+While the vulnerability itself is universal for the platform, it requires device/OEM specific tricks to get root and write the GBL. A lot of those exist for [Xiaomi devices](./brands/xiaomi/README.md#workarounds-use-at-your-own-risk).
+
+#### Other
 
 The general exploit:<br/>
 [alephsecurity.com](https://alephsecurity.com/2018/01/22/qualcomm-edl-2/) the bootloader unlock section.
-
-Xiaomi Mi A1 and maybe all MSM89** manufactured before 2018:<br/>
-[EDLUnlock](https://github.com/Giovix92/EDLUnlock)
 
 ### Unisoc
 If you own a phone with the Unisoc UMS9620 or older,you can use this exploit to achieve temporary secure boot bypass and persistently unlock bootloader(except some devices with modified uboot) [CVE-2022-38694_unlock_bootloader](https://github.com/TomKing062/CVE-2022-38694_unlock_bootloader)

--- a/brands/xiaomi/README.md
+++ b/brands/xiaomi/README.md
@@ -7,113 +7,63 @@ In the past, Xiaomi allowed most of its devices to be unlocked after a period of
 
 With the launch of Xiaomi's new Android fork, HyperOS, they have introduced a number of changes to the unlock process, with new device limits and Mi Account requirements.
 
-Look here if you want to learn about how Ximi's bootloader works: [Xiaomi-bootloader]<br>
-Alternative tools instead of Mi Flash Unlock: [Awesome Xiaomi BootLoader Unlock](https://github.com/topminipie/awesome-xiaomi-bootloader-unlock)
+Unisoc devices will never be unlockable, this is *not* Xiaomi's fault, Unisoc does not allow unlocking. 
 
-Unisoc devices will never be unlockable, this is *not* Xiaomi's fault, Unisoc does not allow unlocking.
+## HyperOS
 
-# China
-**Note**
+It is currently **impossible** to officially unlock Xiaomi phones from the China region, especially if the device was imported and you are outside China. They have removed the unlocking function in their community app.
 
-The specifics of what can and cannot be done change over time, and different sources may claim different things depending on the time period.
-
-
-
-### Devices running HyperOS 2 (China region)
-
-It is currently **impossible** to unlock Xiaomi phones from the China region, especially if the device was imported and you are outside China. They have removed the unlocking function in their community app.
-
-### Workarounds (use at your own risk)
-- **Bootloader Bypass tools**
-  **For all Xiaomi 8E and devices with android security patch before 2/2026 may be able to unlcok thought the vulnerbility released on Coolapk. Most 8E5 devices can be unlocked as long as it has security patch before 2/2026. The 8E5 vulnerbility works by first using (`fastboot oem set-gpu-preemption-value 0 androidboot.selinux=permissive`) then (`fastboot continue`) and lastly (`adb shell service call miui.mqsas.IMQSNative 21 i32 1 s16 "toybox" i32 1 s16 'nc -s 127.0.0.1 -p 1234 -L sh -l' s16 '/data/mqsas/log.txt' i32 60`) to gain root. Qualcomm's proprietary verification mechanism allows an unsigned Generic Boot Loader (GBL) UEFI application to be flashed and executed from the efisp partition. Because this unsigned application runs early in the boot sequence within the privileged Android Boot Loader (ABL) environment, it achieves arbitrary code execution before critical security milestones are enforced. Leveraging this execution window, the application can call internal ABL functions designed to interface with the Replay Protected Memory Block (RPMB), allowing it to modify the devinfo partition, overwrite the tamper-evident lock state, and successfully bypass the bootloader lock. The 8E one works basically the same.**
-  -  ~~[Xiaomi-HyperOS-BootLoader-Bypass](xiaomi-hyperos-bootLoader-bypass) Xiaomi has patch the orginal vulnerbility.~~
-  - **AQLR** – Script-based, requires running at **00:00 China time** on PC (Doesn't work for Chinese phones)
-  - **HyperSploit** – User-friendly program, patched as of **HyperOS 2.0.203.0**, works only on older builds - Can bypass the 30 days old account requirement.
-  - **MlgmXyysd** - MlgmXyysd, the developer of the original bootloader bypass script, has discovered a new vulnerability in Qualcomm devices that enables bootloader unlocking on most HyperOS 2 and 3 phones. You may contact her on CoolAPK; according to some sources, she charges 600 per unlocking. (Not recommended)
-  - [Xiaomi 15 and other 8 Elite](https://xdaforums.com/t/guide-breakthrough-free-offline-bootloader-unlock-for-cn-xiaomi15-pro-ultra-redmi-k90-sd-8-elite-also-support-8g2-8g3-no-cn-exam-required.4786790/) devices can be unlocked if on the January 2026 patch or earlier. [Another exploit](https://xdaforums.com/t/unlock-bootloader-unbrick-xiaomi-8-elite-high-versions-auth-free-edl-firehose.4787466/) for 8 Elite devices exists, using EDL to flash the ABL from an engineering ROM, however this does not work on and **will hard brick** devices with a Toshiba or Kioxia UFS.
-- These tools try to exploit a vulnerability in the Community App request step so you can continue the 7-day waiting process and then unlock with Xiaomi’s official tool.  
-- ⚠️ **Risks**: Using bypasses may get your device or account banned by Xiaomi.  
-
-### Other reports
-- Some users claim that visiting a Xiaomi store and asking a technician to downgrade the system version results in a temporary unlocked state. A few reported flashing their own system during this process — **Basically impossible** due to Xiaomi now using A/B flashing
-
-
-
-### Devices running HyperOS 1
-- Some may still be unlockable using bypass tools.  
-- However, success is not guaranteed and bans are possible.  
-
-
-
-### Devices running MIUI 14 and below
-- These devices generally still support the **“classic” unlock process** (Mi Account login → Developer Options request → wait ~7 days → Mi Unlock tool), without requiring the Community App exam.  
-
-
-
-### Timeline & Reports
-- The last official day to submit unlock requests via the old form was reportedly **September 9, 2024**.  
-- Xiaomi has hinted in the Community App that the service *may return in 2025*, but similar promises have not been fulfilled in the past.  
-- Multiple forum posts suggest that **only users physically located in China, with Level 5 accounts, and valid Chinese ID can currently unlock**. Others sometimes resort to paid third-party services, though results vary.
-- In **1/1/2026** Xiaomi offically remove the unlocking function from their community app.
-- On **2/1/2026** MlgmXyysd the devloper of the orginal bootloader bypass claim she had found a way to unlock Qualcomm devices using a unknown vulnerability
-- On about **5/1/2026** Someone leaked the vulnerbility for 8E5.
-- On about **10/1/2026** The vulnerbility for 8E was leaked.
-
-
-
-📖 **Further Reading:**  
-- [Xiaomi BootLoader Questionnaire Questions](https://github.com/MlgmXyysd/Xiaomi-BootLoader-Questionnaire) – community-collected notes and exam details.  
-
-### Global
-
-> [!WARNING]
-> Since October 2024 [there have been rumors][bootloader-unlock-block-global] that Xiaomi will kill bootloader unlocking on the Global market, after having done so for the China market.
->
-> If you own a Xiaomi device and your warranty has ended or you don't care for it, you should unlock your device while you can.
-
-### Devices running HyperOS (even if they were upgraded to it from MIUI)
-
-First of all we should clear up something: HyperOS is essentially a new marketing term for what would've been MIUI 15. So it's still a vendor skin/theming engine on top of Linux-based Android, it's just called HyperOS instead of MIUI as it used to be called.
-
-Secondly: One might remember how, in order to unlock the device back in the good old MIUI days, you would:
-
-* Ensure a Xiaomi account was logged in on the device in the Settings app
-* Go to Developer Options > Mi Unlock Status and press the button to request your device to be unlocked in the Xiaomi servers
-* Then after 3 days you can use the [official Mi Unlock][MiUnlock] for Windows or [offici5l][offici5l]'s Python [MiUnlockTool][py-MiUnlockTool] which will check those servers to see if a request has been made for that specific device and allow you to unlock it.
-
-Not straightforward or fast, but doable.
-WELL:
-
-With HyperOS Xiaomi essentially makes the second stop more compilated.
-
-That is, you can only make the request for unlocking the device inside Developer Options, ONLY AFTER you have made another SEPARATE successful request inside the Xiaomi Community App, which will then allow you to make the ACTUAL first request you wanted inside the Developer Settings (![yo dawg…][yo-dawg-meme])
+With HyperOS, Xiaomi introduced an additional step to the unlock process. You can make the request for unlocking the device inside Developer Options, only after you have made another separate successful request inside the Xiaomi Community App.
 
 If [xiaomiui.net][global-requirements] is to be believed, the requirements for the Community App request are as follows:
 * Your Mi Account has been active for more than 30 days.
 * Xiaomi Community App version 5.3.31 or above.
-* Xiaomi has [updated their policies][updated-policies], further restricting bootloader unlocking. As of January 1st, 2025, they only let you unlock 1 device per year. *What a good way to start the year, right?* This requirement has also been added to MIUI 14.
+* [As of January 1st, 2025][updated-policies], Xiaomi only let you unlock 1 device per year. This requirement has also been extended to MIUI 14.
 
-And it gets even better! As people have found it the hard way [in the xda forums][community-app-cap], there is a cap on the amount of people who can request per day inside the Community App, and it gets filled pretty much instantly, so your only chance to make a successful request there is if you get lucky spamming the request at midnight, Beijing time (or whatever that is in your timezone).
+Additionally, [on xda forums][community-app-cap] people have found that there is a cap on the amount of people who can request per day inside the Community App, and it gets filled pretty much instantly, so your only chance to make a successful request there is if you get lucky spamming the request at midnight, Beijing time ([GMT+8][gmt+8]).
 
-As such, for as long as the option is available, you'll skip this community BS and use the bypass methods:
+### Workarounds
+
+#### Snapdragon 8 Elite
+
+All of those methods chain the QCOM SELinux bypass, and the Xiaomi MQSAS service privilege escalation vulnerabilities.
+
+- Xiaomi 17 series, POCO F8 Ultra, Redmi K90 Pro Max with Security Patch before February 2026: [XDA](https://xdaforums.com/t/xiaomi17-series-and-pocof8ultra-redmi-k90-pro-max-unlock-bootloader-xiaomi8elite5seriesbootloader-unlock.4781439/)
+- Xiaomi 13, 14, 15 series, MIX Flip 2, Pad 8 Pro, Pad 6S Pro, Redmi K90/K80/K70/K60 Pro with Security Patch before January 2026: [XDA](https://xdaforums.com/t/guide-breakthrough-free-offline-bootloader-unlock-for-cn-xiaomi15-pro-ultra-redmi-k90-sd-8-elite-also-support-8g2-8g3-no-cn-exam-required.4786790/)
+
+It's theoretically possible to downgrade and unlock **non Kioxia UFS** devices using an EDL programmer and an engineering ABL: [XDA](https://xdaforums.com/t/unlock-bootloader-unbrick-xiaomi-8-elite-high-versions-auth-free-edl-firehose.4787466/)
+
+### Other
 
 * [AQLR][aqlr] The current bypass method, though you need to have your computer running at 00:00 Chinese ([GMT+8][gmt+8]) time. (The script is in AQLR.zip at the end of the post.)
-  * At the very end, [offici5l][offici5l]'s Python [MiUnlockTool][py-MiUnlockTool] can be used instead of the official Windows only [Mi Unlock][MiUnlock].
+* **MlgmXyysd** - MlgmXyysd, the developer of the original bootloader bypass script, has discovered a new vulnerability in Qualcomm devices that enables bootloader unlocking on most HyperOS 2 and 3 phones. You may contact her on CoolAPK; according to some sources, she charges 600(??) per unlock.
+* Some users claim that visiting a Xiaomi store and asking a technician to downgrade the system version results in a temporary unlocked state. A few reported flashing their own system during this process.
 * ~~[HyperSploit][hypersploit] is the newer option. This is a simple to use program with no external dependencies.~~ Confirmed as patched as of HyperOS version 2.0.203.0. Still works on old versions.
 * ~~[Xiaomi-HyperOS-BootLoader-Bypass][xiaomi-hyperos-bootLoader-bypass] is the original proof of concept, but it's written in PHP and it's cumbersome to set up.~~ Same as above.
 
-This will (for now) allow you to continue with the last of the **bad old MIUI days** steps, where you wait for 3 (used to be 7) days and can then unlock your phone successfully.
-Do NOT make a new request by pressing the button in the Settings app as that will undo you bypass (hypersploit, MiUnlockTool and Mi Unlock also mention this to you). The tool will make the needed request itself.
-The only thing you need to do is use Xiaomi's [official Mi Unlock][MiUnlock] or [offici5l][offici5l]'s [Python script][py-MiUnlockTool] after 3 days.
+At the very end of the unlock process, [offici5l][offici5l]'s Python [MiUnlockTool][py-MiUnlockTool] can be used instead of the official Windows only [Mi Unlock][MiUnlock].
 
-### Devices running MIUI 14 and below
+### Further Reading
 
-You should be able to use the "normal" unlock process by itself, wihtout the community app BS
-(the one descibed in the "bad old MIUI days" section above).
+- [Xiaomi BootLoader Questionnaire Questions](https://github.com/MlgmXyysd/Xiaomi-BootLoader-Questionnaire) – community-collected notes and exam details. 
 
-## Workarounds
-On some old Devices 9008 or MTK client might be able be unlock.
-Xiaomikey could also work on some devices.
+## MIUI 14 and below
+
+You should be able to use the "normal" unlock process, without the Community app.
+
+* Ensure a Xiaomi account was logged in on the device in the Settings app
+* Go to Developer Options > Mi Unlock Status and press the button to request your device to be unlocked in the Xiaomi servers
+* Then after 7+ days you can use the [official Mi Unlock][MiUnlock] for Windows or [offici5l][offici5l]'s Python [MiUnlockTool][py-MiUnlockTool] which will check those servers to see if a request has been made for that specific device and allow you to unlock it.
+
+### Workarounds
+
+EDL based unlock tool for Xiaomi Mi A1 and maybe all MSM89** manufactured before 2018:<br/>
+[EDLUnlock](https://github.com/Giovix92/EDLUnlock)
+
+### Further Reading
+
+Look here if you want to learn about how Xiaomi's bootloader used to work: [Xiaomi-bootloader] <br/>
+Alternative tools instead of Mi Flash Unlock: [Awesome Xiaomi BootLoader Unlock](https://github.com/topminipie/awesome-xiaomi-bootloader-unlock)
 
 
 ## Android One
@@ -123,7 +73,7 @@ Xiaomikey could also work on some devices.
 Devices shipping with Android One do NOT have any unlock requirements. They follow the standard Android unlock process.
 
 ***
-Updated info provided by [n1ses](https://github.com/n1ses) & [Crimson Fork/🌌🏳️‍⚧️&ΘΔ](https://cf.spaceport.nexus)  & [Mluo2011](https://github.com/Mluo2011)<br/>
+Updated info provided by [n1ses](https://github.com/n1ses) & [Crimson Fork/🌌🏳️‍⚧️&ΘΔ](https://cf.spaceport.nexus)  & [Mluo2011](https://github.com/Mluo2011) <br/>
 Authored by [zenfyr](https://zenfyr.dev).
 
 [hypersploit]:https://github.com/TheAirBlow/HyperSploit


### PR DESCRIPTION
opening this as a PR bc i'm not really sure how much of this info is still accurate (i do not own a single xiaomi device atp), also maybe someone else will chime in.

i don't believe that EDLUnlock itself was ever confirmed to work on non-xiaomi devices, i remember seeing a similar approach on ZTE devices, but nothing outside that. OnePlus devices from the same time period use a different partition as far as i'm aware.