### PR TITLE
add Fairphone 4

### DIFF
--- a/brands/fairphone/README.md
+++ b/brands/fairphone/README.md
@@ -10,7 +10,7 @@ Not very fair in my opinion, but whatever fairs your phone.
 
 They also [broke Verified Boot][verified-boot], lol
 
-With firmware FP3.6.A.040.2 on the Fairphone 3 and with firmware FP6.QREL.16.69.0 on the Fairphone (Gen. 6), Fairphone switched to the [standard unlock procedure]((../../misc/generic-unlock.md)), however all other Fairphone devices still require their website.
+With firmware FP3.6.A.040.2 on the Fairphone 3, with firmware FP4.QREL.15.17.2 on the Fairphone 4 and with firmware FP6.QREL.16.69.0 on the Fairphone (Gen. 6), Fairphone switched to the [standard unlock procedure]((../../misc/generic-unlock.md)), however all other Fairphone devices still require their website.
 
 ***
 Authored by [zenfyr](https://zenfyr.dev).


### PR DESCRIPTION
Fairphone 4 has now the same unlock process as the Fairphone 3 and Fairphone (Gen. 6)