### PR TITLE
Add Onn Devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The following manufacturers require an online account and/or a waiting period be
 
 ### [OnePlus](./brands/oneplus/README.md)
 
+### [Onn](./brands/onn/README.md)
+
 ### [Sony](./brands/sony/README.md)
 
 ### [Tecno](./brands/tecno/README.md)

--- a/brands/onn/README.md
+++ b/brands/onn/README.md
@@ -7,9 +7,7 @@
 
 Note that Onn is a GPL violator and does not release kernel sources so custom roms have generally not be built on Onn tablets. Luckily, GSIs still tend to work from reports.
 
-
-It looks like the general pattern is that snapdragon devices can be bootloader unlocked [1](https://xdaforums.com/t/aio-guide-onn-11-pro-tablet-2024-100146660-root-firmware-otas-gsi.4709806/), but mtk cannot [1](https://xdaforums.com/t/root-how-to-almost-root-any-onn-tablet-all-generations.4662408/#:~:text=NOT%20WORK%20WITH%202023%2011%22%20PRO%20MODELS).
-
+It looks like the general pattern is that snapdragon devices can be bootloader unlocked [1](https://xdaforums.com/t/aio-guide-onn-11-pro-tablet-2024-100146660-root-firmware-otas-gsi.4709806/), but mtk cannot [1](https://xdaforums.com/t/root-how-to-almost-root-any-onn-tablet-all-generations.4662408/#:~:text=NOT%20WORK%20WITH%202023%2011%22%20PRO%20MODELS). Having said that though, you still are better off confirming whether the specific tablet you have can actually be bootloader unlocked or not.
 
 ***
 Authored by [Snuupy](https://github.com/Snuupy).

--- a/brands/onn/README.md
+++ b/brands/onn/README.md
@@ -1,0 +1,15 @@
+# Onn
+
+- Verdict: **ℹ️ "Safe for now" :trollface:** (Qualcomm Snapdragon)
+- Verdict: **⛔ Avoid!** (MediaTek)
+
+<!--  **⛔ Avoid!**, **⚠️ Proceed with caution!**, **ℹ️ "Safe for now" :trollface:** -->
+
+Note that Onn is a GPL violator and does not release kernel sources so custom roms have generally not be built on Onn tablets. Luckily, GSIs still tend to work from reports.
+
+
+It looks like the general pattern is that snapdragon devices can be bootloader unlocked [1](https://xdaforums.com/t/aio-guide-onn-11-pro-tablet-2024-100146660-root-firmware-otas-gsi.4709806/), but mtk cannot [1](https://xdaforums.com/t/root-how-to-almost-root-any-onn-tablet-all-generations.4662408/#:~:text=NOT%20WORK%20WITH%202023%2011%22%20PRO%20MODELS).
+
+
+***
+Authored by [Snuupy](https://github.com/Snuupy).


### PR DESCRIPTION
I may not necessarily maintain this information but this is current and (to the best of my knowledge) correct as of my research recently.

It would likely be ephemerally (as they release new models every/other year) helpful for users to know that:

bootloader unlockable:
- 2024 Onn 11" SD685 64GB

not bootloader unlockable:
- 2026 Onn 11" MTK G99 128GB

...other models to come