### PR TITLE
LG devices with hidden Fastboot can gain access to it by wiping LAF

### DIFF
--- a/brands/lg/README.md
+++ b/brands/lg/README.md
@@ -14,7 +14,7 @@ Newer LG budget phones (2018+) from the K and Stylo series typically do not have
 
 On most LG devices with fastboot mode hidden, fastboot can usually be accessed by wiping LG Download mode otherwise known as LAF. It is usually wiped either with root (devices prior to 2015) or EDL (devices since 2015).
 
-Most carrier branded LG devices (aside from T-Mobile versions made before 2018) also usually have hidden or no Fastboot as well.
+Most carrier branded LG devices (aside from T-Mobile branded devices made before 2018) also usually have hidden Fastboot as well.
 
 ## Watches
 All LG watches on Android Wear/Wear OS use the [standard unlock procedure](../../misc/generic-unlock.md) via fastboot.

--- a/brands/lg/README.md
+++ b/brands/lg/README.md
@@ -10,9 +10,11 @@ On some models (such as the Stylo 3 Plus and G6), the bootloader can still be of
 
 Older devices (prior to 2015) do not have partition verification (on operating system versions made prior to 2015) and assuming you have a root exploit, you can just flash modified partitions with dd -- as recommended by some official LineageOS [install guides]
 
-Newer LG budget phones (2018+) from the K and Stylo series typically do not have Fastboot.
+Newer LG budget phones (2018+) from the K and Stylo series typically do not have visible Fastboot.
 
-Most carrier branded LG devices (aside from T-Mobile versions) also usually have hidden or no Fastboot as well.
+On these devices, fastboot can usually be accessed by wiping LG Download mode otherwise known as LAF.
+
+Most carrier branded LG devices (aside from T-Mobile versions made before 2018) also usually have hidden or no Fastboot as well.
 
 ## Watches
 All LG watches on Android Wear/Wear OS use the [standard unlock procedure](../../misc/generic-unlock.md) via fastboot.

--- a/brands/lg/README.md
+++ b/brands/lg/README.md
@@ -12,7 +12,7 @@ Older devices (prior to 2015) do not have partition verification (on operating s
 
 Newer LG budget phones (2018+) from the K and Stylo series typically do not have visible Fastboot.
 
-On these devices, fastboot can usually be accessed by wiping LG Download mode otherwise known as LAF.
+On most LG devices with fastboot mode hidden, fastboot can usually be accessed by wiping LG Download mode otherwise known as LAF. It is usually wiped either with root (devices prior to 2015) or EDL (devices since 2015).
 
 Most carrier branded LG devices (aside from T-Mobile versions made before 2018) also usually have hidden or no Fastboot as well.
 
@@ -20,7 +20,7 @@ Most carrier branded LG devices (aside from T-Mobile versions made before 2018) 
 All LG watches on Android Wear/Wear OS use the [standard unlock procedure](../../misc/generic-unlock.md) via fastboot.
 
 ## Unofficial methods
-Aside from the generic unofficial methods for devices with MediaTek and Unisoc SoCs, some of their devices with Qualcomm SoCs have leaked engineering bootloaders available, for example the LG G7.
+Aside from the generic unofficial methods for devices with MediaTek and Unisoc SoCs, some of their devices with Qualcomm SoCs have leaked [engineering bootloaders][SDM845 ENG Boot] available, for example the LG G7.
 
 There are also some bootloader exploits such as [CVE-2020-12753] ([PoC]) ([Working example]) that allow bootloader unlock as well.
 
@@ -39,3 +39,5 @@ Authored by [Ivy / Lost-Entrepreneur439](https://github.com/Lost-Entrepreneur439
 [TMO Fastboot commands removed]:https://xdaforums.com/t/v10-bootloop-fix-lengthens-life.3694064/post-74461372
 
 [Working example]:https://xdaforums.com/t/rle888-bootloader-unlock-exploit-for-the-lg-g5.4792237/
+
+[SDM845 ENG Boot]:https://xdaforums.com/t/guide-guide-to-unlock-bootloader-for-every-lg-sdm845-except-g710tm-with-photos.4168771/


### PR DESCRIPTION
LG devices that _look_ like they don't have Fastboot mode do actually have Fastboot mode but it's hidden under LAF (LG Download mode), if the partition is wiped, Fastboot mode will become available.