### PR TITLE
Update README with specific Sony device unlock info

### DIFF
--- a/brands/sony/README.md
+++ b/brands/sony/README.md
@@ -26,7 +26,7 @@ Sony supports [Custom AVB](../../README.md#custom-avb-keys) Since 2020.
 
 You also can't unlock Japan carrier variants, for some reason - Japanese factory unlocked is unaffected.
 
-All Sony devices using the Snapdragon 835 and Snapdragon 845 can be unlocked via the [xperable exploit][xperable].
+Sony Xperia XZ1 (`poplar`, `poplar_dsds`, `poplar_kddi`), XZ1 Compact (lilac) and XZ2 (Tama) and XZ3 (Katsuki), including Japan Units like `au`, `Softbank` and `Docomo` using the Snapdragon 835 and Snapdragon 845 can be unlocked via the [xperable exploit][xperable].
 
 ***
 Info about Japan devices provided by [madeline-yana](https://github.com/madeline-yana) and edited by [eepymeowers](https://github.com/eepymeowers)


### PR DESCRIPTION
Clarified details on unlockable Sony devices using Snapdragon 835 and 845.

You could use the Xperable on other non-mentioned devices, but its advisable not to mention ALL of Xperia devices can work. Because we dont want someone to have an expectation that a Sony Mark 1, locked in Japan or something recent can be certain to be unlockable.

Remember, Xperable relies on CVE-2021-1931. More recent devices may not work unless the author of the Xperable, j4nn made an announcement that it confirms that it is working.